### PR TITLE
Because of changes in the structure of crospi_application_template, I…

### DIFF
--- a/betfsm_demos/betfsm_demos/example_advanced.py
+++ b/betfsm_demos/betfsm_demos/example_advanced.py
@@ -133,7 +133,7 @@ def main(args=None):
     get_logger().info("skill_example_1 started")
     blackboard = {}
 
-    load_task_list("$[crospi_application_template]/skill_specifications/libraries/skill_lib_example/tasks/skill_example.json",blackboard)
+    load_task_list("$[betfsm_demos]/tasks/skill_example.json",blackboard)
     
     get_logger().info("Creating state machine: ")
 

--- a/betfsm_demos/betfsm_demos/example_with_output.py
+++ b/betfsm_demos/betfsm_demos/example_with_output.py
@@ -56,7 +56,7 @@ def main(args=None):
     set_logger("crospi",my_node.get_logger())
     
     blackboard = {}
-    load_task_list("$[crospi_application_template]/skill_specifications/libraries/skill_lib_example/tasks/skill_example.json",blackboard)    
+    load_task_list("$[betfsm_demos]/tasks/skill_example.json",blackboard)
 
     # running MySequence() and cleaning up when CTRL_C is pressed        
     nominal_sm = Repeat("repeat",-1,MySequence())

--- a/betfsm_demos/betfsm_demos/skill_example_1.py
+++ b/betfsm_demos/betfsm_demos/skill_example_1.py
@@ -75,7 +75,7 @@ def main(args=None):
     get_logger().info("skill_example_1 started")
     blackboard = {}
 
-    load_task_list("$[crospi_application_template]/skill_specifications/libraries/skill_lib_example/tasks/skill_example.json",blackboard)
+    load_task_list("$[betfsm_demos]/tasks/skill_example.json",blackboard)
     
     get_logger().info("Creating state machine: ")
     sm = MyStateMachine()

--- a/betfsm_demos/betfsm_demos/skill_example_2.py
+++ b/betfsm_demos/betfsm_demos/skill_example_2.py
@@ -51,7 +51,7 @@ def main(args=None):
     set_logger("crospi",my_node.get_logger())
     get_logger().info("skill_example_2 started")
     blackboard = {}
-    load_task_list("$[crospi_application_template]/skill_specifications/libraries/skill_lib_example/tasks/skill_example.json",blackboard)
+    load_task_list("$[betfsm_demos]/tasks/skill_example.json",blackboard)
     sm = MySequence()
     runner = ROSRunner(my_node,sm,blackboard, frequency=100.0, publish_frequency=5.0, debug=True, display_active=True)
     try:

--- a/betfsm_demos/betfsm_demos/skill_example_3.py
+++ b/betfsm_demos/betfsm_demos/skill_example_3.py
@@ -61,7 +61,7 @@ def main(args=None):
     get_logger().info("This example cleans up after a ctrl-c using a cleanup state machine")
     
     blackboard = {}
-    load_task_list("$[crospi_application_template]/skill_specifications/libraries/skill_lib_example/tasks/skill_example.json",blackboard)
+    load_task_list("$[betfsm_demos]/tasks/skill_example.json",blackboard)
     
 
     # running MySequence() and cleaning up when CTRL_C is pressed        

--- a/betfsm_demos/betfsm_demos/skill_example_4.py
+++ b/betfsm_demos/betfsm_demos/skill_example_4.py
@@ -65,7 +65,7 @@ def main(args=None):
     get_logger().info("skill_example_4 started")
     blackboard = {}
 
-    load_task_list("$[crospi_application_template]/skill_specifications/libraries/skill_lib_example/tasks/skill_example.json",blackboard)
+    load_task_list("$[betfsm_demos]/tasks/skill_example.json",blackboard)
     
     get_logger().info("Now cleaning up after a ctrl-c using a cleanup TickingState")
 

--- a/betfsm_demos/tasks/skill_example.json
+++ b/betfsm_demos/tasks/skill_example.json
@@ -1,0 +1,138 @@
+{
+    "$schema":"tasks-schema.json",
+    "tasks": [
+        {
+            "name": "MovingHome",
+            "task_specification": {
+                "from-core_task_lib-version-0.1.0": true,
+                "is-move_jointspace_trap": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/core_task_lib/task_specifications/move_jointspace_trap.etasl.lua",
+                "parameters": {
+                    "maxacc": 0.1,
+                    "maxvel": 0.1,
+                    "target_joints": [1.5708, -1.5708, 2.0944, -2.0944, -1.5708, 0],
+                    "units": "radians"
+                }
+            }
+        },
+        {
+            "name": "MovingSpline",
+            "task_specification":{
+                "from-core_task_lib-version-0.1.0": true,
+                "is-follow_spline": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/core_task_lib/task_specifications/follow_spline.etasl.lua",
+                "parameters": {
+                    "csv_file_path": "$[crospi_application_template]/task_specifications/libraries/core_task_lib/task_specifications/misc/example_spline.csv",
+                    "maxacc": 0.1,
+                    "maxvel": 0.1,
+                    "task_frame": "tcp_frame"
+                }
+            }
+        },
+        {
+            "name": "MovingDown",
+            "task_specification": {
+                "from-core_task_lib-version-0.1.0": true,
+                "is-move_cartesianspace_relative": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/core_task_lib/task_specifications/move_cartesianspace_relative.etasl.lua",
+                "parameters": {
+                    "delta_pos": [0, 0, -0.2],
+                    "eq_r": 0.08,
+                    "maxacc": 0.1,
+                    "maxvel": 0.1,
+                    "delta_euler": [
+                        0,
+                        0,
+                        0
+                    ],
+                    "task_frame": "tcp_frame",
+                    "wrt_frame": "world_frame"
+                }
+            }
+        },
+        {
+            "name": "MovingUp",
+            "task_specification": {
+                "from-core_task_lib-version-0.1.0": true,
+                "is-move_cartesianspace_relative": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/core_task_lib/task_specifications/move_cartesianspace_relative.etasl.lua",
+                "parameters": {
+                    "delta_pos": [0, 0, 0.2],
+                    "eq_r": 0.08,
+                    "maxacc": 0.1,
+                    "maxvel": 0.1,
+                    "delta_euler": [
+                        0,
+                        0,
+                        0
+                    ],
+                    "task_frame": "tcp_frame",
+                    "wrt_frame": "world_frame"
+                }
+            }
+        },
+        {
+            "name": "MovingAdmittance",
+            "task_specification":{
+                "from-core_task_lib-version-0.1.0": true,
+                "is-move_admittance": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/core_task_lib/task_specifications/move_admittance.etasl.lua",
+                "parameters": {
+                    "activate_angular": false,
+                    "activate_linear": false,
+                    "K_r": 400,
+                    "K_t": 4000,
+                    "task_frame": "tcp_frame",
+                    "FT_sensor_frame": "FT_sensor_frame",
+                    "force_threshold": 0.5,
+                    "torque_threshold": 0.05,
+                    "tool_COG": [
+                        0,
+                        0,
+                        0
+                    ],
+                    "tool_weight": 0
+                }
+            }
+        },
+        {
+            "name": "follow_tf",
+            "task_specification":{
+                "from-dummy_lib-version-0.1.0": true,
+                "is-follow_external_frame": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/dummy_lib/task_specifications/follow_external_frame.etasl.lua",
+                "parameters": {
+                    "task_frame": "tcp_frame",
+                    "tf_name_var": "tf_to_follow" 
+                }
+            }
+        },
+        {
+            "name": "follow_position_vector",
+            "task_specification":{
+                "from-dummy_lib-version-0.1.0": true,
+                "is-follow_external_vector": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/dummy_lib/task_specifications/follow_external_vector.etasl.lua",
+                "parameters": {
+                    "task_frame": "tcp_frame",
+                    "vector_name_var": "vector_to_follow"
+                }
+            }
+        },
+        {
+            "name": "keep_frame",
+            "task_specification":{
+                "from-core_task_lib-version-0.1.0": true,
+                "is-keep_relative_initial_pose": true,
+                "file_path": "$[crospi_application_template]/task_specifications/libraries/core_task_lib/task_specifications/keep_relative_initial_pose.etasl.lua",
+                "parameters": {
+                    "base_frame": "board_pose",
+                    "execution_time": 0,
+                    "task_frame": "tcp_frame",
+                    "activate_angular": false,
+                    "activate_linear": true
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
… changed the examples to use load task parameters from local json (such that it becomes easier to maintain both packages separately)

@eaertbel If you agree please merge to main. Otherwise point to the new directory:
    #load_task_list("$[crospi_application_template]/skill_specifications/libraries/skill_lib_example/skill_example_loop_fsm/skill_example_loop_fsm.json",blackboard)

but I don't recommend it because now there is more than one example and it might create confusion.
